### PR TITLE
Fix test for ImagePullSecrets test

### DIFF
--- a/testdata/deployment_pullsecret/output/deployment_value.yaml
+++ b/testdata/deployment_pullsecret/output/deployment_value.yaml
@@ -1,5 +1,5 @@
 deploymentStrategy: RollingUpdate
-imagePullSecrets: mypullsecret
+imagePullSecrets: my-pull-secret
 namespace: default
 nginx:
   image: nginx


### PR DESCRIPTION
The original `imagePullSecret` name provided by user is left unchanged in the values file.

cc:  @yadavnikhil 